### PR TITLE
Fix exception processing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 language: python
-python: 3.3
-env:
-  matrix:
-    - TOXENV=coverage
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py34
+matrix:
+  include:
+    - env: TOXENV=coverage
+    - env: TOXENV=py27
+      python: 2.7
+    - env: TOXENV=py34
+      python: 3.4
+    - env: TOXENV=py35
+      python: 3.5
+    - env: TOXENV=py36
+      python: 3.6
+    - env: TOXENV=py37
+      python: 3.7
+      dist: xenial
+      sudo: true
 install: pip install docutils tox
 script: tox

--- a/tests/test_visio2img.py
+++ b/tests/test_visio2img.py
@@ -28,7 +28,7 @@ if is_pywin32_available():
         app = win32com.client.Dispatch('Visio.InvisibleApp')
         app.Quit()
         VISIO_AVAILABLE = True
-    except:
+    except Exception:
         pass
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py33,py34
+envlist=py27,py34,py35,py36,py37
 
 [testenv]
 deps=

--- a/visio2img/visio2img.py
+++ b/visio2img/visio2img.py
@@ -71,7 +71,7 @@ class VisioFile(object):
         try:
             import win32com.client
             self.app = win32com.client.Dispatch('Visio.InvisibleApp')
-        except:
+        except Exception:
             msg = 'Visio not found. visio2img requires Visio.'
             raise OSError(msg)
 
@@ -86,7 +86,7 @@ class VisioFile(object):
                 self.app.Documents.OpenEx(visio_pathname, open_flags)
             else:
                 self.app.Documents.Open(visio_pathname)
-        except:
+        except Exception:
             self.close()
             msg = 'Could not open file (already opend by other process?): %s'
             raise IOError(msg % filename)
@@ -126,7 +126,7 @@ def export_img(visio_filename, image_filename, pagenum=None, pagename=None):
                 for i, page in enumerate(pages):
                     filename = filename_format % (i + 1)
                     page.Export(filename)
-        except:
+        except Exception:
             raise IOError('Could not write image: %s' % image_pathname)
 
 


### PR DESCRIPTION
Travis CI test is failed by following log:

```
py27 runtests: commands[1] | flake8 setup.py visio2img/ tests/
visio2img/visio2img.py:74:9: E722 do not use bare except'
visio2img/visio2img.py:89:9: E722 do not use bare except'
visio2img/visio2img.py:129:9: E722 do not use bare except'
tests/test_visio2img.py:31:5: E722 do not use bare except'
ERROR: InvocationError: '/home/travis/build/visio2img/visio2img/.tox/py27/bin/flake8 setup.py visio2img/ tests/'
___________________________________ summary ____________________________________
ERROR:   py27: commands failed
```

So, above code should be fixed.