### PR TITLE
Update python versions for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 language: python
-python: 3.3
-env:
-  matrix:
-    - TOXENV=coverage
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py34
+matrix:
+  include:
+    - env: TOXENV=coverage
+    - env: TOXENV=py27
+      python: 2.7
+    - env: TOXENV=py34
+      python: 3.4
+    - env: TOXENV=py35
+      python: 3.5
+    - env: TOXENV=py36
+      python: 3.6
+    - env: TOXENV=py37
+      python: 3.7
+      dist: xenial
+      sudo: true
 install: pip install docutils tox
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py33,py34
+envlist=py27,py34,py35,py36,py37
 
 [testenv]
 deps=


### PR DESCRIPTION
Nowadays, Travis CI does not support python3.3. And new python3 releases are shiped for now.
Therefore this replaces old py33 by new python interpreters.

This does not mean dropping py33 support, but it will be needed in next release.
I believe nobody uses py33 at present...